### PR TITLE
Allow pushing to RubyGems

### DIFF
--- a/ania.gemspec
+++ b/ania.gemspec
@@ -13,14 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/fac/ania"
   spec.license       = "Apache License, Version 2.0"
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
We need to be able to push to RubyGems so we can install it from there instead of using Github once it's open source.
